### PR TITLE
Make compostable items registration for thread safety

### DIFF
--- a/src/main/java/net/redchujelly/cluttered/Cluttered.java
+++ b/src/main/java/net/redchujelly/cluttered/Cluttered.java
@@ -70,27 +70,28 @@ public class Cluttered {
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.WILLOW_LEAVES.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_CARPET_WILLOW.get().asItem(), 0.075F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.WILLOW_SAPLING.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.WILLOW_VINES.get().asItem(), 0.5F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.POPLAR_LEAVES.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_CARPET_POPLAR.get().asItem(), 0.075F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_POPLAR_LEAVES.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.POPLAR_SAPLING.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.CRABAPPLE_LEAVES.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_CARPET_CRABAPPLE.get().asItem(), 0.075F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.CRABAPPLE_SAPLING.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.SYCAMORE_LEAVES.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.SYCAMORE_SAPLING.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.MAPLE_LEAVES_FLOWERING.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.MAPLE_LEAVES.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.MAPLE_SAPLING.get().asItem(), 0.3F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.BLUE_MUSHROOM_SAPLING.get().asItem(), 0.65F);
-        ComposterBlock.COMPOSTABLES.put(BlockRegistration.RED_MUSHROOM_SAPLING.get().asItem(), 0.65F);
-
         event.enqueueWork(() ->
         {
+            // FMLCommonSetupEvent is processed concurrently with other Mods, while COMPOSTABLES is actually an Object2FloatMap, which is not thread-safe. Therefore, registration must be completed serially on the main thread!
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.WILLOW_LEAVES.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_CARPET_WILLOW.get().asItem(), 0.075F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.WILLOW_SAPLING.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.WILLOW_VINES.get().asItem(), 0.5F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.POPLAR_LEAVES.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_CARPET_POPLAR.get().asItem(), 0.075F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_POPLAR_LEAVES.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.POPLAR_SAPLING.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.CRABAPPLE_LEAVES.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.FLOWERING_CARPET_CRABAPPLE.get().asItem(), 0.075F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.CRABAPPLE_SAPLING.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.SYCAMORE_LEAVES.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.SYCAMORE_SAPLING.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.MAPLE_LEAVES_FLOWERING.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.MAPLE_LEAVES.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.MAPLE_SAPLING.get().asItem(), 0.3F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.BLUE_MUSHROOM_SAPLING.get().asItem(), 0.65F);
+            ComposterBlock.COMPOSTABLES.put(BlockRegistration.RED_MUSHROOM_SAPLING.get().asItem(), 0.65F);
+            
             ((FlowerPotBlock) Blocks.FLOWER_POT).addPlant(BlockRegistration.WILLOW_SAPLING.getId(), BlockRegistration.POTTED_WILLOW_SAPLING);
             ((FlowerPotBlock) Blocks.FLOWER_POT).addPlant(BlockRegistration.POPLAR_SAPLING.getId(), BlockRegistration.POTTED_POPLAR_SAPLING);
             ((FlowerPotBlock) Blocks.FLOWER_POT).addPlant(BlockRegistration.CRABAPPLE_SAPLING.getId(), BlockRegistration.POTTED_CRABAPPLE_SAPLING);


### PR DESCRIPTION
Since I installed this mod on my server, I have noticed that the server randomly crashes at startup, generating the following crash report:
```
Details:
	Mod File: server/mods/cluttered-[Forge]-3.0.2-1.20.1.jar
	Failure message: Cluttered (cluttered) encountered an error during the common_setup event phase
		java.lang.ArrayIndexOutOfBoundsException: Index 1024 out of bounds for length 513
	Mod Version: 3.0.2-1.20.1
	Mod Issue URL: NOT PROVIDED
	Exception message: java.lang.ArrayIndexOutOfBoundsException: Index 1024 out of bounds for length 513
Stacktrace:
	at it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap.rehash(Object2FloatOpenHashMap.java:1350) ~[fastutil-8.5.9.jar%2390!/:?] {}
	at it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap.insert(Object2FloatOpenHashMap.java:249) ~[fastutil-8.5.9.jar%2390!/:?] {}
	at it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap.put(Object2FloatOpenHashMap.java:257) ~[fastutil-8.5.9.jar%2390!/:?] {}
	at net.redchujelly.cluttered.Cluttered.commonSetup(Cluttered.java:83) ~[cluttered-%5BForge%5D-3.0.2-1.20.1.jar%23251!/:3.0.2-1.20.1] {re:classloading}
```
The error occurred during the rehash phase, and coincidentally, the accessed index 1024 is twice the maximum safe index 512 (corresponding to the array length 513) of the array. This doubling behavior evidently occurred during the expansion of HashMap (or Object2FloatMap, as the case may be). For some reason, the underlying stored array did not complete the expansion correctly, but the rehash work had already begun. Coupled with the characteristic of random occurrence, my experience tells me that this is likely a thread race condition issue.

The Forge documentation also confirms this point: in fact, FMLCommonSetupEvent is executed concurrently across multiple mods. Running Cluttered alone may not cause any issues, but if multiple mods are installed on the server simultaneously and another mod happens to operate on COMPOSTABLES during this period, this problem may arise. Therefore, I have made modifications to this part to ensure that the registration of COMPOSTABLES is only completed on the main thread, which may solve this issue.