### PR TITLE
Fixed Chair Entity Serialization Methods 

### DIFF
--- a/src/main/java/net/redchujelly/cluttered/entity/ChairEntity.java
+++ b/src/main/java/net/redchujelly/cluttered/entity/ChairEntity.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ChairEntity extends Entity {
 
-    private final BlockPos CHAIR_POS;
+    private BlockPos CHAIR_POS;
     private final Level CHAIR_LEVEL;
 
     public ChairEntity(EntityType<?> pEntityType, Level pLevel) {
@@ -33,10 +33,18 @@ public class ChairEntity extends Entity {
 
     @Override
     protected void readAdditionalSaveData(CompoundTag compoundTag) {
+        CHAIR_POS = new BlockPos(
+        compoundTag.getInt("ChairX"),
+        compoundTag.getInt("ChairY"),
+        compoundTag.getInt("ChairZ")
+        );
     }
 
     @Override
     protected void addAdditionalSaveData(CompoundTag compoundTag) {
+        compoundTag.putInt("ChairX", CHAIR_POS.getX());
+        compoundTag.putInt("ChairY", CHAIR_POS.getY());
+        compoundTag.putInt("ChairZ", CHAIR_POS.getZ());
     }
 
     @Override
@@ -44,6 +52,17 @@ public class ChairEntity extends Entity {
         this.teleportTo(this.getX(), this.getY() + 0.5f, this.getZ());
         super.removePassenger(pPassenger);
         kill();
+    }
+
+    @Override
+    public void tick(){
+        super.tick();
+        if(!level().isClientSide){
+            BlockState state = level().getBlockState(CHAIR_POS);
+            if(getPassengers().isEmpty() || !state.hasProperty(BlockStateProperties.OCCUPIED)) {
+                kill();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Bug/Prior to fix (this change would need added to the 1.21 branch)

On world reload the BlockPos would default to 0, 0, 0 from the constructor
This would cause the player if they had not dismounted to be stuck/embedded in the chair/camera fixed on the x and z. 
Entities infrequently became/become stale from lack of tick cleanup

summarization of fixes: 
Wrote the X Y Z Block Positions into their proper serialization methods for the entity. Chair_Pos needed to be made not final since it was grabbing the new value through deserialization on reload.  

Additionally added the tick method to clean up stale entities/chair entities without a passenger on the server. I noticed this bug when sitting on a server with a friend, inconsistently the chair after dismounting would have a stale entity/not be usable without breaking/killing the chair entity. 

Testing/How to reproduce on older branches:
I checked this/you can reproduce the bug in the 1.21/branch prior to this fix by disconnecting while being a passenger to the ottoman stool for example, For the stale entity the Ottoman reproduced the stale entity most, just using and dismounting caused it to occur prior. 